### PR TITLE
Add httpx to API requirements

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.30.6
 supertokens-python==0.22.1
 python-multipart==0.0.9
 python-jose[cryptography]==3.3.0
+httpx==0.26.0


### PR DESCRIPTION
## Summary
- add pinned httpx dependency for the API service

## Testing
- `pip install -r api/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68ad571b8298832aa1fd316eb3ca2368